### PR TITLE
Add list of our current open source crates

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,4 +61,4 @@ Let's go! 🚀
 Open source Rust crates we've created and are using/maintaining:
 
 * [`buildkite-jobify`](https://github.com/EmbarkStudios/buildkite-jobify) - Kubekite, but in Rust, using configuration from your repos
-* [`cargo-deny`](https://github.com/EmbarkStudios/cargo-deny) - Crate license whitelist and deny list tool
+* [`cargo-deny`](https://github.com/EmbarkStudios/cargo-deny) - Tool to maintaining your entire crate graph in large repositories


### PR DESCRIPTION
Thought it would be nice to have a central listing of them here on our main Rust entry point that will be open (http://embark.rs), for easy discovery for users as well as for ourselves :) 

Let's keep this up-to-date with our repos and add stuff here when we make it public. And make sure we have a good one-liner descriptions of them here as well (can be the GitHub repo description, which also should be good and short).