### PR TITLE
Fix outdated link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,6 @@ We believe that open source creators are integral to the success of the Rust eco
 
 We're actively looking to collaborate with developers on the areas discussed in this repository. If you're interested in working on a specific issue or idea highlighted here, please reach out to us at [`opensource@embark-studios.com`](mailto:opensource@embark-studios.com) to discuss contracting opportunities or sponsorship.
 
-We are also [hiring](https://embark.games/careers/) for full-time positions in Stockholm!
+We are also [hiring](https://embark.games/jobs/) for full-time positions in Stockholm!
 
 Let's go! 🚀


### PR DESCRIPTION


### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

The old link redirects to `/departments/careers` but that returned a 404. The new link works.
