### PR TITLE
Embark standard lints v0.3

### DIFF
--- a/lints.rs
+++ b/lints.rs
@@ -32,6 +32,7 @@
     clippy::mismatched_target_os,
     clippy::needless_borrow,
     clippy::needless_continue,
+    clippy::needless_pass_by_value,
     clippy::option_option,
     clippy::pub_enum_variant_names,
     clippy::ref_option_ref,

--- a/lints.rs
+++ b/lints.rs
@@ -1,4 +1,4 @@
-// BEGIN - Embark standard lints v0.2
+// BEGIN - Embark standard lints v0.3
 // do not change or add/remove here, but one can add exceptions after this section
 // for more info see: <https://github.com/EmbarkStudios/rust-ecosystem/issues/59>
 #![deny(unsafe_code)]
@@ -21,6 +21,7 @@
     clippy::linkedlist,
     clippy::lossy_float_literal,
     clippy::macro_use_imports,
+    clippy::map_err_ignore,
     clippy::map_flatten,
     clippy::map_unwrap_or,
     clippy::match_on_vec_items,
@@ -43,6 +44,6 @@
     nonstandard_style,
     rust_2018_idioms
 )]
-// END - Embark standard lints v0.2
+// END - Embark standard lints v0.3
 // crate-specific exceptions:
 #![allow()]

--- a/lints.rs
+++ b/lints.rs
@@ -32,7 +32,6 @@
     clippy::mismatched_target_os,
     clippy::needless_borrow,
     clippy::needless_continue,
-    clippy::needless_pass_by_value,
     clippy::option_option,
     clippy::pub_enum_variant_names,
     clippy::ref_option_ref,

--- a/lints.rs
+++ b/lints.rs
@@ -35,6 +35,8 @@
     clippy::pub_enum_variant_names,
     clippy::ref_option_ref,
     clippy::rest_pat_in_fully_bound_structs,
+    clippy::string_add_assign,    
+    clippy::string_add,
     clippy::string_to_string,
     clippy::suboptimal_flops,
     clippy::todo,

--- a/lints.rs
+++ b/lints.rs
@@ -42,6 +42,7 @@
     clippy::string_to_string,
     clippy::suboptimal_flops,
     clippy::todo,
+    clippy::unimplemented,
     clippy::unnested_or_patterns,
     clippy::unused_self,
     clippy::verbose_file_reads,

--- a/lints.rs
+++ b/lints.rs
@@ -17,6 +17,7 @@
     clippy::if_let_mutex,
     clippy::imprecise_flops,
     clippy::inefficient_to_string,
+    clippy::large_types_passed_by_value,
     clippy::let_unit_value,
     clippy::linkedlist,
     clippy::lossy_float_literal,

--- a/lints.rs
+++ b/lints.rs
@@ -26,6 +26,7 @@
     clippy::map_flatten,
     clippy::map_unwrap_or,
     clippy::match_on_vec_items,
+    clippy::match_same_arms,
     clippy::match_wildcard_for_single_variants,
     clippy::mem_forget,
     clippy::mismatched_target_os,


### PR DESCRIPTION
## Current plan for v0.3

- Add: [`map_err_ignore`](https://rust-lang.github.io/rust-clippy/master/index.html#map_err_ignore) - prevents loosing error context and works well in Ark, easy to ignore when needed 
- Add: [`match_same_arms`](https://rust-lang.github.io/rust-clippy/master/index.html#match_same_arms) - seems to work well and simplifies matching code to reduce complexity, with some exceptions.
- Add: [`large_types_passed_by_value`](https://rust-lang.github.io/rust-clippy/master/index.html#large_types_passed_by_value) - seems like a good idea, could catch some things should be boxed. no warns in Ark.
- Add: [`string_add`](https://rust-lang.github.io/rust-clippy/master/index.html#string_add) - cleaner & more explicit, only 1 easy fixed warn in Ark.
- Add: [`string_add_assign`](https://rust-lang.github.io/rust-clippy/master/index.html#string_add_assign) - cleaner & more explicit, only 1 easy fixed warn in Ark.
- Add: [`explicit_iter_loop`](https://rust-lang.github.io/rust-clippy/master/index.html#explicit_iter_loop) - we already use [`explicit_into_iter_loop`](https://rust-lang.github.io/rust-clippy/master/index.html#explicit_into_iter_loop) in v0.2, should enable or disable both.
- Add: [`unimplemented`](https://rust-lang.github.io/rust-clippy/master/#unimplemented) - good for stubbing out WIP code but want to avoid on `main` our crates & systems are live at head

The [`match_same_arms`](https://rust-lang.github.io/rust-clippy/master/index.html#match_same_arms) lint is definitely the most intrusive change of these, and may need some opt outs in a few cases when one doesn't want to re-order code, but have been quite favored still.

## Under consideration, but currently not in v0.3

Some discussion in the PR but think these require more testing or follow up.

- Add: [`needless_pass_by_value`](https://rust-lang.github.io/rust-clippy/master/#needless_pass_by_value) - helped us catch a lot of unnecessary `: Vec<T>` arguments and replace them with `: &[T]`, saving a lot of calls to `.clone()` (very common trap for rust beginners to fall into). quite intrusive change for lots of crates though so safer to do separtely
- Remove: [`doc_markdown`](https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown) - has a 4y old outstanding issue on acronyms that it wants to force codeformatting backticks on which is quite messy and requires a lot of manual disabling (or a `clippy.toml` config): https://github.com/rust-lang/rust-clippy/issues/1136
- Remove: [`pub_enum_variant_names`](https://rust-lang.github.io/rust-clippy/master/index.html#pub_enum_variant_names) - pretty common for this one to trigger in valid/good cases, so is a bit hit & miss.
- Remove: [`suboptimal_flops`](https://rust-lang.github.io/rust-clippy/master/#suboptimal_flops) - rearranges code quite significantly with `mul_add`


Will leave this as a draft for a while and feel free to discuss & suggest additional additions or removals