### PR TITLE
Deny `broken_intra_doc_links`, `invalid_codeblock_attributes`, `private_inra_doc_links`

### DIFF
--- a/lints.rs
+++ b/lints.rs
@@ -1,6 +1,9 @@
 // BEGIN - Embark standard lints v0.3
 // do not change or add/remove here, but one can add exceptions after this section
 // for more info see: <https://github.com/EmbarkStudios/rust-ecosystem/issues/59>
+#![deny(broken_intra_doc_links)]
+#![deny(invalid_codeblock_attributes)]
+#![deny(private_intra_doc_links)]
 #![deny(unsafe_code)]
 #![warn(
     clippy::all,
@@ -36,7 +39,7 @@
     clippy::pub_enum_variant_names,
     clippy::ref_option_ref,
     clippy::rest_pat_in_fully_bound_structs,
-    clippy::string_add_assign,    
+    clippy::string_add_assign,
     clippy::string_add,
     clippy::string_to_string,
     clippy::suboptimal_flops,

--- a/lints.rs
+++ b/lints.rs
@@ -1,10 +1,12 @@
 // BEGIN - Embark standard lints v0.3
 // do not change or add/remove here, but one can add exceptions after this section
 // for more info see: <https://github.com/EmbarkStudios/rust-ecosystem/issues/59>
-#![deny(broken_intra_doc_links)]
-#![deny(invalid_codeblock_attributes)]
-#![deny(private_intra_doc_links)]
-#![deny(unsafe_code)]
+#![deny(
+    broken_intra_doc_links,
+    invalid_codeblock_attributes,
+    private_intra_doc_links,
+    unsafe_code,
+)]
 #![warn(
     clippy::all,
     clippy::await_holding_lock,


### PR DESCRIPTION
These are warnings by default. Explained at https://doc.rust-lang.org/rustdoc/lints.html