### PR TITLE
Add lints as `.cargo/config.toml` section

### DIFF
--- a/lints.toml
+++ b/lints.toml
@@ -1,6 +1,6 @@
 # add the below section to `.cargo/config.toml`
 
-[build]
+[target.'cfg(all())']
 rustflags = [
     # BEGIN - Embark standard lints v0.4
     # do not change or add/remove here, but one can add exceptions after this section


### PR DESCRIPTION
Adds an alternate way to enable our standard lints (#59) for all this crates in a repository through `.cargo/config.toml` section. Inspired by https://github.com/rust-lang/cargo/issues/5034#issuecomment-927105016.

We are testing this as a workaround for #22 until Cargo/Clippy supports a proper mechanism to configure lints for an entire repository/workspace, and seems to work really well so far. One of our big repositories has 80+ crates and all of them had the previous lint code definitions in every lib.rs/main.rs copy'n'pasted and this will replace all of that and make it dramatically easier to manage and less error prone.