### PR TITLE
Remove renamed warn-by-default lints, v6 lint set

### DIFF
--- a/lints.rs
+++ b/lints.rs
@@ -1,4 +1,4 @@
-// BEGIN - Embark standard lints v5 for Rust 1.55+
+// BEGIN - Embark standard lints v6 for Rust 1.55+
 // do not change or add/remove here, but one can add exceptions after this section
 // for more info see: <https://github.com/EmbarkStudios/rust-ecosystem/issues/59>
 #![deny(unsafe_code)]
@@ -9,8 +9,6 @@
     clippy::checked_conversions,
     clippy::dbg_macro,
     clippy::debug_assert_with_mut_call,
-    clippy::disallowed_method,
-    clippy::disallowed_type,
     clippy::doc_markdown,
     clippy::empty_enum,
     clippy::enum_glob_use,

--- a/lints.toml
+++ b/lints.toml
@@ -2,7 +2,7 @@
 
 [target.'cfg(all())']
 rustflags = [
-    # BEGIN - Embark standard lints v5 for Rust 1.55+
+    # BEGIN - Embark standard lints v6 for Rust 1.55+
     # do not change or add/remove here, but one can add exceptions after this section
     # for more info see: <https://github.com/EmbarkStudios/rust-ecosystem/issues/59>
     "-Dunsafe_code",
@@ -12,8 +12,6 @@ rustflags = [
     "-Wclippy::checked_conversions",
     "-Wclippy::dbg_macro",
     "-Wclippy::debug_assert_with_mut_call",
-    "-Wclippy::disallowed_method",
-    "-Wclippy::disallowed_type",
     "-Wclippy::doc_markdown",
     "-Wclippy::empty_enum",
     "-Wclippy::enum_glob_use",


### PR DESCRIPTION
`disallowed_type` and `disallowed_method` has been renamed to plural names in Rust 1.59 and also now are warn-by-default so we do not need to enable them anymore explicitly

Part of #59 
Replaces #73
