### PR TITLE
Fix clap link

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Projects we are currently sponsoring:
 * __[Dimforge](https://www.dimforge.com/)__ - _"Open-Source Rust crates for numerical simulation"_
 * __[rust-analyzer](https://github.com/rust-analyzer/rust-analyzer)__ - _"Bringing a great IDE experience
 to the Rust programming language"_
-* __[Clap](https://clap.rs)__ - _"Fast. Configurable. Argument Parsing for Rust"_
+* __[Clap](https://github.com/clap-rs/clap)__ - _"Fast. Configurable. Argument Parsing for Rust"_
 * __[Gtk-rs](https://gtk-rs.org/)__ - _"Rust bindings for GTK+ 3, Cairo, GtkSourceView and other GLib-compatible libraries"_
 * __[knurling-rs](https://knurling.ferrous-systems.com/)__ - _"Improving the tools and material used to build, debug, and learn embedded systems"_
 * __[Tokio](https://tokio.rs)__ - _"Build reliable network applications without compromising speed"_


### PR DESCRIPTION
This is a tiny fix for the clap link.
Apparently, they don't use the https://clap.rs page.