### PR TITLE
Audit `egui` crates

### DIFF
--- a/audits.toml
+++ b/audits.toml
@@ -374,6 +374,12 @@ No unsafe usage or ambient capabilities itself, used in production since 2020.
 Written by Emil Ernerfeldt who used to work with us at Embark Studios.
 """
 
+[[audits.egui]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+delta = "0.18.0 -> 0.19.0"
+notes = "No unsafe usage and no ambient capabilities"
+
 [[audits.epaint]]
 who = "Johan Andersson <opensource@embark-studios.com>"
 criteria = "safe-to-deploy"
@@ -383,6 +389,13 @@ No unsafe usage or ambient capabilities itself, used in production since 2020.
 
 Written by Emil Ernerfeldt who used to work with us at Embark Studios.
 """
+
+[[audits.epaint]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+delta = "0.18.0 -> 0.19.0"
+notes = "No unsafe usage and no ambient capabilities"
+
 
 # TODO: uncomment this when an new version with fully defined licenses has been released
 #[[audits.epaint]]
@@ -402,13 +415,25 @@ Math crate with no unsafe usage or ambient capabilities, used in production sinc
 Written by Emil Ernerfeldt who used to work with us at Embark Studios.
 """
 
+[[audits.emath]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+delta = "0.18.0 -> 0.19.0"
+notes = "No unsafe usage and no ambient capabilities"
+
 [[audits.egui-winit]]
 who = "Johan Andersson <opensource@embark-studios.com>"
 criteria = "safe-to-deploy"
 version = "0.18.0"
 notes = """
-No unsafe usage or ambient capabilities itself, used in production since 2020.
-Does interact with clipboard, but through separate crate.
+No unsafe usage, does layer with windowing system (which is the point of the crate). Used in production since 2020.
+Does optionally interact with clipboard, webbrowser, and screen-reader; but through separate crates.
 
 Written by Emil Ernerfeldt who used to work with us at Embark Studios.
 """
+
+[[audits.egui-winit]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+delta = "0.18.0 -> 0.19.0"
+notes = "Minor sane unsafe usage and no new ambient capabilities"

--- a/audits.toml
+++ b/audits.toml
@@ -390,6 +390,14 @@ No unsafe usage or ambient capabilities itself, used in production since 2020.
 Written by Emil Ernerfeldt who used to work with us at Embark Studios.
 """
 
+# TODO: uncomment this when an new version with fully defined licenses has been released
+#[[audits.epaint]]
+#who = "Johan Andersson <opensource@embark-studios.com>"
+#criteria = "safe-to-deploy"
+#violation = "*" # TODO: specify new version as cap here
+#notes = "Specified crate license does not include licenses of embedded fonts if using default features or the `default_fonts` feature. Tracked in: https://github.com/emilk/egui/issues/2321"
+
+
 [[audits.emath]]
 who = "Johan Andersson <opensource@embark-studios.com>"
 criteria = "safe-to-deploy"

--- a/audits.toml
+++ b/audits.toml
@@ -162,12 +162,6 @@ criteria = "safe-to-deploy"
 version = "0.30.0"
 notes = "Maintained by the Ark team at Embark"
 
-[[audits.ash-molten]]
-who = "Johan Andersson <opensource@embark-studios.com>"
-criteria = "safe-to-deploy"
-version = "0.12.0+1.1.5"
-notes = "Maintained by the Ark team at Embark"
-
 # can't have ranges for pre-releases so have to have a lot of duplication here
 
 [[audits.spirv-std]]

--- a/audits.toml
+++ b/audits.toml
@@ -162,6 +162,12 @@ criteria = "safe-to-deploy"
 version = "0.30.0"
 notes = "Maintained by the Ark team at Embark"
 
+[[audits.ash-molten]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "0.12.0+1.1.5"
+notes = "Maintained by the Ark team at Embark"
+
 # can't have ranges for pre-releases so have to have a lot of duplication here
 
 [[audits.spirv-std]]
@@ -340,9 +346,9 @@ who = "Johan Andersson <opensource@embark-studios.com>"
 criteria = "safe-to-deploy"
 version = "0.3.1"
 notes = """
-No unsafe and no dependencies except math (glam).
+No unsafe and no dependencies except math (glam), used it in production since 2021.
 
-Written by Tomasz Stachowiak as side-project while employed with us at Embark Studios, and we've used it in production since 2021
+Written by Tomasz Stachowiak as side-project while employed with us at Embark Studios.
 """
 
 [[audits.similar-asserts]]
@@ -362,3 +368,35 @@ who = "Johan Andersson <opensource@embark-studios.com>"
 criteria = "safe-to-deploy"
 version = "0.1.1"
 notes = "Tiny crate that initializes Android with FFI, looks sane. No other ambient capabilities"
+
+
+[[audits.egui]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "0.18.0"
+notes = """
+No unsafe usage or ambient capabilities itself, used in production since 2020.
+
+Written by former Emil Ernerfeldt who used to work with us at Embark Studios.
+"""
+
+[[audits.emath]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "0.18.0"
+notes = """
+Math crate with no unsafe usage or ambient capabilities, used in production since 2020.
+
+Written by former Emil Ernerfeldt who used to work with us at Embark Studios.
+"""
+
+[[audits.egui-winit]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "0.18.0"
+notes = """
+No unsafe usage or ambient capabilities itself, used in production since 2020.
+Does interact with clipboard, but through separate crate.
+
+Written by former Emil Ernerfeldt who used to work with us at Embark Studios.
+"""

--- a/audits.toml
+++ b/audits.toml
@@ -377,7 +377,17 @@ version = "0.18.0"
 notes = """
 No unsafe usage or ambient capabilities itself, used in production since 2020.
 
-Written by former Emil Ernerfeldt who used to work with us at Embark Studios.
+Written by Emil Ernerfeldt who used to work with us at Embark Studios.
+"""
+
+[[audits.epaint]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "0.18.0"
+notes = """
+No unsafe usage or ambient capabilities itself, used in production since 2020.
+
+Written by Emil Ernerfeldt who used to work with us at Embark Studios.
 """
 
 [[audits.emath]]
@@ -387,7 +397,7 @@ version = "0.18.0"
 notes = """
 Math crate with no unsafe usage or ambient capabilities, used in production since 2020.
 
-Written by former Emil Ernerfeldt who used to work with us at Embark Studios.
+Written by Emil Ernerfeldt who used to work with us at Embark Studios.
 """
 
 [[audits.egui-winit]]
@@ -398,5 +408,5 @@ notes = """
 No unsafe usage or ambient capabilities itself, used in production since 2020.
 Does interact with clipboard, but through separate crate.
 
-Written by former Emil Ernerfeldt who used to work with us at Embark Studios.
+Written by Emil Ernerfeldt who used to work with us at Embark Studios.
 """


### PR DESCRIPTION
Yes I did actually manually (lightly) audit all these crates by opening up the exact versions and looking for `unsafe` usage (none found!), dependencies, ambient capabilities through std/core, and such. 

And looks good! reviewing large Rust crates is not that hard when not using any such features :100:  Thanks @emilk :smiley: 

Did find one under specified license though in `epaint` that I've stubbed out as a violation here
- Filed: https://github.com/emilk/egui/issues/2321
- Once this is resolved later we can enable the violation so previous versions will fail to be audited due to it. But can't do it yet because would fail `cargo vet` in our projects.

Part of:
- https://github.com/EmbarkStudios/ark/issues/6167
- https://github.com/EmbarkStudios/ark/issues/7090 

